### PR TITLE
Update docker container to support ARM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-slim
 
 SHELL ["/bin/bash", "-c"]
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8-slim
 SHELL ["/bin/bash", "-c"]
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
 RUN apt-get update
-RUN apt-get install -y cron xvfb firefox wget
+RUN apt-get install -y cron xvfb firefox wget vim
 RUN wget -c https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz && tar -xzf geckodriver-v0.23.0-linux64.tar.gz -C /usr/local/bin/
 RUN chown root:root /usr/local/bin/geckodriver
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.8-slim-buster
+FROM python:3.8
 
 SHELL ["/bin/bash", "-c"]
 RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-RUN apt-get update && apt-get install -y cron xvfb firefox wget vim
+RUN apt-get update
+RUN apt-get install -y cron xvfb firefox wget
 RUN wget -c https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz && tar -xzf geckodriver-v0.23.0-linux64.tar.gz -C /usr/local/bin/
 RUN chown root:root /usr/local/bin/geckodriver
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker buildx build --push --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag strenkml/afraid-autologin:latest .


### PR DESCRIPTION
- The docker base image had to be update because using python:3.8-slim-buster wasn't building anymore.
- The docker image was built for linux/arm/v7, linux/arm64/v8, and linux/amd64 and pushed to dockerhub.